### PR TITLE
Using lastMessageId instead of timestamp is often more precise and ef…

### DIFF
--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -11,18 +11,18 @@ const { Op } = require("sequelize");
 //     res.json(messages);
 // };
 
-exports.fetchMessage = async (req, res) => {
+exports.getMessage = async (req, res) => {
     try {
-        const after = req.query.after;
+        const lastMessageId = parseInt(req.query.lastMessageId);
 
-        const whereClause = after
-            ? { createdAt: { [Op.gt]: new Date(after) } }
+        const whereClause = !isNaN(lastMessageId)
+            ? { id: { [Op.gt]: lastMessageId } }
             : {};
 
         const messages = await Message.findAll({
             where: whereClause,
             include: { model: User, attributes: ["name"] },
-            order: [["createdAt", "ASC"]],
+            order: [["id", "ASC"]],
         });
 
         res.json(messages);

--- a/backend/routes/chatRoutes.js
+++ b/backend/routes/chatRoutes.js
@@ -1,12 +1,12 @@
 const express = require("express");
 
-const { fetchMessage, addMessage } = require("../controllers/chatController");
+const { getMessage, addMessage } = require("../controllers/chatController");
 
 const { authenticate } = require("../middlewares/auth");
 
 const router = express.Router();
 
-router.get("/messages", authenticate, fetchMessage);
+router.get("/messages", authenticate, getMessage);
 router.post("/messages", authenticate, addMessage);
 
 module.exports = router;

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -18,17 +18,17 @@ function renderMessages(messages) {
     });
 }
 
-function getLastMessageTimestamp() {
+function getLastMessageId() {
     if (allMessages.length === 0) return null;
-    return allMessages[allMessages.length - 1].createdAt;
+    return allMessages[allMessages.length - 1].id;
 }
 
 async function fetchNewMessages() {
-    const after = getLastMessageTimestamp();
+    const lastId = getLastMessageId();
     try {
         const res = await axios.get(`http://localhost:3000/api/messages`, {
             headers: { Authorization: `Bearer ${token}` },
-            params: after ? { after } : {},
+            params: lastId ? { lastMessageId: lastId } : {},
         });
 
         const newMessages = res.data;


### PR DESCRIPTION
Using lastMessageId instead of timestamp is often more precise and efficient, especially when multiple messages are sent at the same time